### PR TITLE
Implementation of the STUDYBOX-106 - Adding results endpoint

### DIFF
--- a/backend/app/src/main/java/com/bls/patronage/api/FlashcardRepresentation.java
+++ b/backend/app/src/main/java/com/bls/patronage/api/FlashcardRepresentation.java
@@ -2,13 +2,16 @@ package com.bls.patronage.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.hibernate.validator.constraints.Length;
+import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.validation.constraints.NotNull;
 
 public class FlashcardRepresentation {
-    @Length(min = 1, max = 1000)
+    @NotEmpty
+    @Length(max = 1000)
     private final String question;
-    @Length(min = 1, max = 1000)
+    @NotEmpty
+    @Length(max = 1000)
     private final String answer;
 
     public FlashcardRepresentation(@JsonProperty("question") String question, @JsonProperty("answer") String answer) {

--- a/backend/app/src/main/java/com/bls/patronage/api/FlashcardRepresentation.java
+++ b/backend/app/src/main/java/com/bls/patronage/api/FlashcardRepresentation.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.hibernate.validator.constraints.Length;
 import org.hibernate.validator.constraints.NotEmpty;
 
-import javax.validation.constraints.NotNull;
-
 public class FlashcardRepresentation {
     @NotEmpty
     @Length(max = 1000)

--- a/backend/app/src/main/java/com/bls/patronage/api/FlashcardRepresentation.java
+++ b/backend/app/src/main/java/com/bls/patronage/api/FlashcardRepresentation.java
@@ -6,29 +6,20 @@ import org.hibernate.validator.constraints.Length;
 import javax.validation.constraints.NotNull;
 
 public class FlashcardRepresentation {
+    @Length(min = 1, max = 1000)
     private final String question;
+    @Length(min = 1, max = 1000)
     private final String answer;
 
-    public FlashcardRepresentation() {
-        question = null;
-        answer = null;
-    }
-
-    public FlashcardRepresentation(String question, String answer) {
+    public FlashcardRepresentation(@JsonProperty("question") String question, @JsonProperty("answer") String answer) {
         this.question = question;
         this.answer = answer;
     }
 
-    @JsonProperty
-    @NotNull
-    @Length(min = 1)
     public String getQuestion() {
         return question;
     }
 
-    @JsonProperty
-    @NotNull
-    @Length(min = 1)
     public String getAnswer() {
         return answer;
     }

--- a/backend/app/src/main/java/com/bls/patronage/api/ResultRepresentation.java
+++ b/backend/app/src/main/java/com/bls/patronage/api/ResultRepresentation.java
@@ -18,6 +18,7 @@ public class ResultRepresentation {
         return flashcardId;
     }
 
+    @JsonProperty("isCorrectAnswer")
     public boolean isCorrectAnswer() {
         return isCorrectAnswer;
     }

--- a/backend/app/src/main/java/com/bls/patronage/api/ResultRepresentation.java
+++ b/backend/app/src/main/java/com/bls/patronage/api/ResultRepresentation.java
@@ -9,9 +9,9 @@ public class ResultRepresentation {
     private boolean isCorrectAnswer;
 
     public ResultRepresentation(@JsonProperty("flashcardId") UUID flashcardId,
-                                @JsonProperty("isCorrectAnswer") boolean correctAnswer) {
+                                @JsonProperty("isCorrectAnswer") boolean isCorrectAnswer) {
         this.flashcardId = flashcardId;
-        this.isCorrectAnswer = correctAnswer;
+        this.isCorrectAnswer = isCorrectAnswer;
     }
 
     public UUID getFlashcardId() {

--- a/backend/app/src/main/java/com/bls/patronage/api/ResultRepresentation.java
+++ b/backend/app/src/main/java/com/bls/patronage/api/ResultRepresentation.java
@@ -2,10 +2,13 @@ package com.bls.patronage.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import javax.validation.constraints.NotNull;
 import java.util.UUID;
 
 public class ResultRepresentation {
+    @NotNull
     private UUID flashcardId;
+    @NotNull
     private boolean isCorrectAnswer;
 
     public ResultRepresentation(@JsonProperty("flashcardId") UUID flashcardId,

--- a/backend/app/src/main/java/com/bls/patronage/api/ResultRepresentation.java
+++ b/backend/app/src/main/java/com/bls/patronage/api/ResultRepresentation.java
@@ -1,0 +1,24 @@
+package com.bls.patronage.api;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.UUID;
+
+public class ResultRepresentation {
+    private UUID flashcardId;
+    private boolean isCorrectAnswer;
+
+    public ResultRepresentation(@JsonProperty("flashcardId") UUID flashcardId,
+                                @JsonProperty("isCorrectAnswer") boolean correctAnswer) {
+        this.flashcardId = flashcardId;
+        this.isCorrectAnswer = correctAnswer;
+    }
+
+    public UUID getFlashcardId() {
+        return flashcardId;
+    }
+
+    public boolean isCorrectAnswer() {
+        return isCorrectAnswer;
+    }
+}

--- a/backend/app/src/main/java/com/bls/patronage/resources/DecksResource.java
+++ b/backend/app/src/main/java/com/bls/patronage/resources/DecksResource.java
@@ -37,7 +37,7 @@ public class DecksResource {
     public Collection<Deck> listDecks(@QueryParam("name") String name,
                                       @QueryParam("isEnabled") Boolean isEnabled) {
         if (name == null) {
-            if (isEnabled == null || isEnabled == false) {
+            if (isEnabled == null || !isEnabled) {
                 return decksDAO.getAllDecks();
             } else {
                 Collection<Deck> decks = new ArrayList<>();

--- a/backend/app/src/main/java/com/bls/patronage/resources/ResultsResource.java
+++ b/backend/app/src/main/java/com/bls/patronage/resources/ResultsResource.java
@@ -14,7 +14,9 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -33,9 +35,15 @@ public class ResultsResource {
     @POST
     public void createResult(@Valid ResultRepresentation result,
                              @Valid @PathParam("deckId") UUIDParam id) {
-        int correctAnswers = resultDAO.getResult(result.getFlashcardId()).getCorrectAnswers() + (result.isCorrectAnswer() ? 1 : 0);
-        Result createdResult = new Result(result.getFlashcardId(), correctAnswers);
-        resultDAO.createResult(createdResult);
+        Set<UUID> uuids = resultDAO.getAllResults(id.get()).stream().map(Result::getId).collect(Collectors.toSet());
+
+        if (!uuids.contains(result.getFlashcardId())) {
+            resultDAO.createResult(new Result(result.getFlashcardId(), 0));
+        } else {
+            int correctAnswers = resultDAO.getResult(result.getFlashcardId()).getCorrectAnswers() + (result.isCorrectAnswer() ? 1 : 0);
+            Result createdResult = new Result(result.getFlashcardId(), correctAnswers);
+            resultDAO.createResult(createdResult);
+        }
     }
 
     @GET

--- a/backend/app/src/main/java/com/bls/patronage/resources/ResultsResource.java
+++ b/backend/app/src/main/java/com/bls/patronage/resources/ResultsResource.java
@@ -1,0 +1,46 @@
+package com.bls.patronage.resources;
+
+import com.bls.patronage.api.ResultRepresentation;
+import com.bls.patronage.db.dao.FlashcardDAO;
+import com.bls.patronage.db.dao.ResultDAO;
+import com.bls.patronage.db.model.Result;
+import io.dropwizard.jersey.params.UUIDParam;
+
+import javax.validation.Valid;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Path("/decks/{deckId}/results")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class ResultsResource {
+    private final FlashcardDAO flashcardDAO;
+    private final ResultDAO resultDAO;
+
+    public ResultsResource(FlashcardDAO flashcardDAO, ResultDAO resultDAO) {
+        this.flashcardDAO = flashcardDAO;
+        this.resultDAO = resultDAO;
+    }
+
+    @POST
+    public void createResult(@Valid ResultRepresentation result,
+                             @Valid @PathParam("deckId") UUIDParam id) {
+        Result createdResult = new Result(result.getFlashcardId(), 0);
+        resultDAO.createResult(createdResult);
+    }
+
+    @GET
+    public List<Result> listResults(@Valid @PathParam("deckId") UUIDParam deckId) {
+        List<UUID> ids = flashcardDAO.getFlashcardsIdFromSelectedDeck(deckId.get());
+        List<Result> results = ids.stream().map(resultDAO::getResult).collect(Collectors.toList());
+        return results;
+    }
+}

--- a/backend/app/src/main/java/com/bls/patronage/resources/ResultsResource.java
+++ b/backend/app/src/main/java/com/bls/patronage/resources/ResultsResource.java
@@ -33,7 +33,8 @@ public class ResultsResource {
     @POST
     public void createResult(@Valid ResultRepresentation result,
                              @Valid @PathParam("deckId") UUIDParam id) {
-        Result createdResult = new Result(result.getFlashcardId(), 0);
+        int correctAnswers = resultDAO.getResult(result.getFlashcardId()).getCorrectAnswers() + (result.isCorrectAnswer() ? 1 : 0);
+        Result createdResult = new Result(result.getFlashcardId(), correctAnswers);
         resultDAO.createResult(createdResult);
     }
 

--- a/backend/app/src/main/java/com/bls/patronage/resources/ResultsResource.java
+++ b/backend/app/src/main/java/com/bls/patronage/resources/ResultsResource.java
@@ -14,7 +14,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;

--- a/backend/app/src/test/java/com/bls/patronage/resources/DeckResourceTest.java
+++ b/backend/app/src/test/java/com/bls/patronage/resources/DeckResourceTest.java
@@ -22,7 +22,6 @@ import javax.ws.rs.core.UriBuilder;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/backend/app/src/test/java/com/bls/patronage/resources/FlashcardsResourceTest.java
+++ b/backend/app/src/test/java/com/bls/patronage/resources/FlashcardsResourceTest.java
@@ -67,7 +67,7 @@ public class FlashcardsResourceTest {
     public void createFlashcardWithoutQuestionAndAnswer() {
         final Response response = resources.client().target(flashcardsURI)
                 .request(MediaType.APPLICATION_JSON_TYPE)
-                .post(Entity.entity(new FlashcardRepresentation(), MediaType.APPLICATION_JSON_TYPE));
+                .post(Entity.entity(new FlashcardRepresentation("", ""), MediaType.APPLICATION_JSON_TYPE));
 
         assertThat(response.getStatus()).isEqualTo(422);
     }

--- a/backend/app/src/test/java/com/bls/patronage/resources/ResultsResourceTest.java
+++ b/backend/app/src/test/java/com/bls/patronage/resources/ResultsResourceTest.java
@@ -60,8 +60,9 @@ public class ResultsResourceTest {
     }
 
     @Test
-    public void createResult() {
+    public void createExistingResult() {
         when(resultDAO.getResult(resultRepresentation.getFlashcardId())).thenReturn(result);
+        when(resultDAO.getAllResults(deckId)).thenReturn(ImmutableList.of(result));
 
         final Response response = resources.client().target(resultsURI)
                 .request(MediaType.APPLICATION_JSON_TYPE)
@@ -71,6 +72,21 @@ public class ResultsResourceTest {
         verify(resultDAO).createResult(resultCaptor.capture());
         assertThat(resultCaptor.getValue().getId()).isEqualTo(resultRepresentation.getFlashcardId());
         assertThat(resultCaptor.getValue().getCorrectAnswers()).isEqualTo(result.getCorrectAnswers() + 1);
+    }
+
+    @Test
+    public void createNewResult() {
+        when(resultDAO.getResult(resultRepresentation.getFlashcardId())).thenReturn(result);
+        when(resultDAO.getAllResults(deckId)).thenReturn(anyListOf(Result.class));
+
+        final Response response = resources.client().target(resultsURI)
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .post(Entity.entity(resultRepresentation, MediaType.APPLICATION_JSON_TYPE));
+
+        assertThat(response.getStatusInfo()).isEqualTo(Response.Status.NO_CONTENT);
+        verify(resultDAO).createResult(resultCaptor.capture());
+        assertThat(resultCaptor.getValue().getId()).isEqualTo(resultRepresentation.getFlashcardId());
+        assertThat(resultCaptor.getValue().getCorrectAnswers()).isEqualTo(0);
     }
 
     @Test

--- a/backend/app/src/test/java/com/bls/patronage/resources/ResultsResourceTest.java
+++ b/backend/app/src/test/java/com/bls/patronage/resources/ResultsResourceTest.java
@@ -1,0 +1,87 @@
+package com.bls.patronage.resources;
+
+import com.bls.patronage.api.FlashcardRepresentation;
+import com.bls.patronage.api.ResultRepresentation;
+import com.bls.patronage.db.dao.FlashcardDAO;
+import com.bls.patronage.db.dao.ResultDAO;
+import com.bls.patronage.db.model.Flashcard;
+import com.bls.patronage.db.model.Result;
+import com.google.common.collect.ImmutableList;
+import io.dropwizard.testing.junit.ResourceTestRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ResultsResourceTest {
+    private static final ResultDAO resultDAO = mock(ResultDAO.class);
+    private static final FlashcardDAO flashcardDAO = mock(FlashcardDAO.class);
+
+    @ClassRule
+    public static final ResourceTestRule resources = ResourceTestRule.builder()
+            .addResource(new ResultsResource(flashcardDAO, resultDAO))
+            .build();
+    @Captor
+    private ArgumentCaptor<Result> resultCaptor;
+    private Result result;
+    private ResultRepresentation resultRepresentation;
+    private String resultsURI;
+    private UUID deckId;
+
+    @Before
+    public void setUp() {
+        result = new Result(UUID.randomUUID(), anyInt());
+        resultRepresentation = new ResultRepresentation(result.getId(), true);
+        deckId = UUID.randomUUID();
+        resultsURI = UriBuilder.fromResource(ResultsResource.class).build(deckId).toString();
+    }
+
+    @After
+    public void tearDown() {
+        reset(resultDAO);
+    }
+
+    @Test
+    public void createResult() {
+        when(resultDAO.getResult(resultRepresentation.getFlashcardId())).thenReturn(result);
+
+        final Response response = resources.client().target(resultsURI)
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .post(Entity.entity(resultRepresentation, MediaType.APPLICATION_JSON_TYPE));
+
+        assertThat(response.getStatusInfo()).isEqualTo(Response.Status.NO_CONTENT);
+        verify(resultDAO).createResult(resultCaptor.capture());
+        assertThat(resultCaptor.getValue().getId()).isEqualTo(resultRepresentation.getFlashcardId());
+        assertThat(resultCaptor.getValue().getCorrectAnswers()).isEqualTo(result.getCorrectAnswers() + 1);
+    }
+
+    @Test
+    public void listResults() {
+        when(flashcardDAO.getFlashcardsIdFromSelectedDeck(deckId)).thenReturn(ImmutableList.of(resultRepresentation.getFlashcardId()));
+        when(resultDAO.getResult(resultRepresentation.getFlashcardId())).thenReturn(result);
+
+        final List<Result> response = resources.client().target(resultsURI)
+                .request().get(new GenericType<List<Result>>() {
+                });
+
+        verify(resultDAO).getResult(resultRepresentation.getFlashcardId());
+        verify(flashcardDAO).getFlashcardsIdFromSelectedDeck(deckId);
+        assertThat(response).contains(result);
+    }
+}

--- a/backend/app/src/test/java/com/bls/patronage/resources/ResultsResourceTest.java
+++ b/backend/app/src/test/java/com/bls/patronage/resources/ResultsResourceTest.java
@@ -6,6 +6,7 @@ import com.bls.patronage.db.dao.FlashcardDAO;
 import com.bls.patronage.db.dao.ResultDAO;
 import com.bls.patronage.db.model.Flashcard;
 import com.bls.patronage.db.model.Result;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.testing.junit.ResourceTestRule;
 import org.junit.After;
@@ -23,6 +24,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import java.util.List;
+import java.util.Random;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,7 +48,7 @@ public class ResultsResourceTest {
 
     @Before
     public void setUp() {
-        result = new Result(UUID.randomUUID(), anyInt());
+        result = new Result(UUID.randomUUID(), new Random().nextInt());
         resultRepresentation = new ResultRepresentation(result.getId(), true);
         deckId = UUID.randomUUID();
         resultsURI = UriBuilder.fromResource(ResultsResource.class).build(deckId).toString();
@@ -69,6 +71,17 @@ public class ResultsResourceTest {
         verify(resultDAO).createResult(resultCaptor.capture());
         assertThat(resultCaptor.getValue().getId()).isEqualTo(resultRepresentation.getFlashcardId());
         assertThat(resultCaptor.getValue().getCorrectAnswers()).isEqualTo(result.getCorrectAnswers() + 1);
+    }
+
+    @Test
+    public void createIncorrectResult() {
+        ResultRepresentation requestEntity = new ResultRepresentation(null, false);
+
+        final Response response = resources.client().target(resultsURI)
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .post(Entity.entity(requestEntity, MediaType.APPLICATION_JSON_TYPE));
+
+        assertThat(response.getStatus()).isEqualTo(422);
     }
 
     @Test

--- a/backend/app/src/test/java/com/bls/patronage/resources/ResultsResourceTest.java
+++ b/backend/app/src/test/java/com/bls/patronage/resources/ResultsResourceTest.java
@@ -1,12 +1,9 @@
 package com.bls.patronage.resources;
 
-import com.bls.patronage.api.FlashcardRepresentation;
 import com.bls.patronage.api.ResultRepresentation;
 import com.bls.patronage.db.dao.FlashcardDAO;
 import com.bls.patronage.db.dao.ResultDAO;
-import com.bls.patronage.db.model.Flashcard;
 import com.bls.patronage.db.model.Result;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.testing.junit.ResourceTestRule;
 import org.junit.After;

--- a/backend/db/src/main/java/com/bls/patronage/db/dao/FlashcardDAO.java
+++ b/backend/db/src/main/java/com/bls/patronage/db/dao/FlashcardDAO.java
@@ -22,6 +22,9 @@ abstract public class FlashcardDAO {
     @SqlQuery("select id,question,answer,deckID from flashcards where deckId = :deckId")
     public abstract List<Flashcard> getAllFlashcards(@Bind("deckId") UUID deckId);
 
+    @SqlQuery("select id from flashcards where deckId = :deckId")
+    public abstract List<UUID> getFlashcardsIdFromSelectedDeck(@Bind("deckId") UUID deckId);
+
     @GetGeneratedKeys
     @SqlUpdate("insert into flashcards values (:id, :question, :answer, :deckID)")
     public abstract UUID createFlashcard(@BindBean Flashcard flashcard);

--- a/backend/db/src/main/java/com/bls/patronage/db/dao/ResultDAO.java
+++ b/backend/db/src/main/java/com/bls/patronage/db/dao/ResultDAO.java
@@ -1,0 +1,36 @@
+package com.bls.patronage.db.dao;
+
+import com.bls.patronage.db.exception.DataAccessException;
+import com.bls.patronage.db.model.Flashcard;
+import com.bls.patronage.db.model.Result;
+import org.skife.jdbi.v2.sqlobject.*;
+import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@RegisterMapper(ResultMapper.class)
+abstract public class ResultDAO {
+
+    @SqlQuery("select flashcardId, correctAnswers from results where flashcardId = :id")
+    abstract Result get(@Bind("id") UUID id);
+
+    @SqlUpdate("insert into results values (:id, :correctAnswers)")
+    public abstract void createResult(@BindBean Result result);
+
+    @SqlUpdate("update results set correctAnswers = :correctAnswers where flashcardId = :id")
+    public abstract void updateResult(@BindBean Result result);
+
+    @SqlUpdate("delete from results where flashcardId = :id")
+    public abstract void deleteResult(@Bind("id") UUID id);
+
+    public Result getResult(UUID id) {
+        Optional<Result> result = Optional.ofNullable(get(id));
+        return result.orElseGet(() -> {
+            Result newResult = new Result(id, 0);
+            createResult(newResult);
+            return newResult;
+        });
+    }
+}

--- a/backend/db/src/main/java/com/bls/patronage/db/dao/ResultDAO.java
+++ b/backend/db/src/main/java/com/bls/patronage/db/dao/ResultDAO.java
@@ -3,7 +3,10 @@ package com.bls.patronage.db.dao;
 import com.bls.patronage.db.exception.DataAccessException;
 import com.bls.patronage.db.model.Flashcard;
 import com.bls.patronage.db.model.Result;
-import org.skife.jdbi.v2.sqlobject.*;
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.BindBean;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
 import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
 
 import java.util.List;
@@ -19,6 +22,10 @@ abstract public class ResultDAO {
     @SqlUpdate("insert into results values (:id, :correctAnswers)")
     public abstract void createResult(@BindBean Result result);
 
+    @SqlQuery("select results.flashcardId, results.correctAnswers from results left join flashcards on results.flashcardId = flashcards.id where flashcards.deckId = :deckId")
+    public abstract List<Result> getAllResults(@Bind("deckId") UUID deckId);
+
+
     @SqlUpdate("update results set correctAnswers = :correctAnswers where flashcardId = :id")
     public abstract void updateResult(@BindBean Result result);
 
@@ -27,10 +34,6 @@ abstract public class ResultDAO {
 
     public Result getResult(UUID id) {
         Optional<Result> result = Optional.ofNullable(get(id));
-        return result.orElseGet(() -> {
-            Result newResult = new Result(id, 0);
-            createResult(newResult);
-            return newResult;
-        });
+        return result.orElseThrow(() -> new DataAccessException("There is no result with specified id"));
     }
 }

--- a/backend/db/src/main/java/com/bls/patronage/db/dao/ResultDAO.java
+++ b/backend/db/src/main/java/com/bls/patronage/db/dao/ResultDAO.java
@@ -1,7 +1,6 @@
 package com.bls.patronage.db.dao;
 
 import com.bls.patronage.db.exception.DataAccessException;
-import com.bls.patronage.db.model.Flashcard;
 import com.bls.patronage.db.model.Result;
 import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.BindBean;

--- a/backend/db/src/main/java/com/bls/patronage/db/dao/ResultMapper.java
+++ b/backend/db/src/main/java/com/bls/patronage/db/dao/ResultMapper.java
@@ -1,0 +1,16 @@
+package com.bls.patronage.db.dao;
+
+import com.bls.patronage.db.model.Result;
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.UUID;
+
+public class ResultMapper implements ResultSetMapper<Result> {
+
+    public Result map(int index, ResultSet r, StatementContext ctx) throws SQLException {
+        return new Result((UUID) r.getObject("flashcardId"), r.getInt("correctAnswers"));
+    }
+}

--- a/backend/db/src/main/java/com/bls/patronage/db/model/Result.java
+++ b/backend/db/src/main/java/com/bls/patronage/db/model/Result.java
@@ -7,6 +7,9 @@ import java.util.UUID;
 public class Result extends IdentifiableEntity {
     private int correctAnswers;
 
+    public Result() {
+    }
+
     public Result(UUID id) {
         super(id);
     }
@@ -34,7 +37,7 @@ public class Result extends IdentifiableEntity {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Result result = (Result) o;
-        return getId() == result.getId() && getCorrectAnswers() == result.getCorrectAnswers();
+        return getId().equals(result.getId()) && getCorrectAnswers() == result.getCorrectAnswers();
     }
 
     @Override

--- a/backend/db/src/main/java/com/bls/patronage/db/model/Result.java
+++ b/backend/db/src/main/java/com/bls/patronage/db/model/Result.java
@@ -1,0 +1,52 @@
+package com.bls.patronage.db.model;
+
+import com.google.common.base.Objects;
+
+import java.util.UUID;
+
+public class Result extends IdentifiableEntity {
+    private int correctAnswers;
+
+    public Result(UUID id) {
+        super(id);
+    }
+
+    public Result(String id) {
+        super(id);
+    }
+
+    public Result(UUID id, int correctAnswers) {
+        super(id);
+        this.correctAnswers = correctAnswers;
+    }
+
+    public Result(String id, int correctAnswers) {
+        super(id);
+        this.correctAnswers = correctAnswers;
+    }
+
+    public int getCorrectAnswers() {
+        return correctAnswers;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Result result = (Result) o;
+        return getId() == result.getId() && getCorrectAnswers() == result.getCorrectAnswers();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getId(), getCorrectAnswers());
+    }
+
+    @Override
+    public String toString() {
+        return "Result{" +
+                "id=" + getId() +
+                "correctAnswers=" + correctAnswers +
+                '}';
+    }
+}

--- a/backend/db/src/main/resources/migrations.xml
+++ b/backend/db/src/main/resources/migrations.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <databaseChangeLog
-        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
@@ -29,6 +29,16 @@
                 <constraints nullable="false"/>
             </column>
             <column name="answer" type="varchar(1000)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet id="2" author="lupi">
+        <createTable tableName="results">
+            <column name="flashcardId" type="uuid">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="correctAnswers" type="int">
                 <constraints nullable="false"/>
             </column>
         </createTable>

--- a/backend/db/src/test/java/com/bls/patronage/dao/DeckDAOTest.java
+++ b/backend/db/src/test/java/com/bls/patronage/dao/DeckDAOTest.java
@@ -8,7 +8,6 @@ import org.junit.Test;
 import org.skife.jdbi.v2.Handle;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/backend/db/src/test/java/com/bls/patronage/dao/ResultDAOTest.java
+++ b/backend/db/src/test/java/com/bls/patronage/dao/ResultDAOTest.java
@@ -1,6 +1,5 @@
 package com.bls.patronage.dao;
 
-import com.bls.patronage.db.dao.FlashcardDAO;
 import com.bls.patronage.db.dao.ResultDAO;
 import com.bls.patronage.db.model.Flashcard;
 import com.bls.patronage.db.model.Result;
@@ -12,8 +11,6 @@ import java.util.Random;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
 
 public class ResultDAOTest extends DAOTest {
 

--- a/backend/db/src/test/java/com/bls/patronage/dao/ResultDAOTest.java
+++ b/backend/db/src/test/java/com/bls/patronage/dao/ResultDAOTest.java
@@ -1,0 +1,102 @@
+package com.bls.patronage.dao;
+
+import com.bls.patronage.db.dao.FlashcardDAO;
+import com.bls.patronage.db.dao.ResultDAO;
+import com.bls.patronage.db.model.Flashcard;
+import com.bls.patronage.db.model.Result;
+import org.junit.Test;
+import org.skife.jdbi.v2.Handle;
+
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+
+public class ResultDAOTest extends DAOTest {
+
+    private Flashcard flashcardExample1;
+    private Flashcard flashcardExample2;
+    private Result resultExample1;
+    private Result resultExample2;
+    private UUID deckID;
+    private ResultDAO dao;
+
+    @Override
+    public void setUp() throws Exception {
+        deckID = UUID.randomUUID();
+        flashcardExample1 = new Flashcard(UUID.randomUUID(), "what are you?", "Just human", deckID);
+        flashcardExample2 = new Flashcard(UUID.randomUUID(), "who are you?", "Proud pole", deckID);
+        resultExample1 = new Result(flashcardExample1.getId(), new Random().nextInt());
+        resultExample2 = new Result(flashcardExample2.getId(), new Random().nextInt());
+
+        super.setUp();
+        dao = dbi.open(ResultDAO.class);
+    }
+
+    @Override
+    protected void setUpDatabaseContent(Handle handle) {
+        handle.createCall("DROP TABLE results IF EXISTS").invoke();
+        handle.createCall(
+                "CREATE TABLE results (flashcardId uuid primary key, correctAnswers int not null)")
+                .invoke();
+        handle.createStatement("INSERT INTO results VALUES (?, ?)")
+                .bind(0, resultExample1.getId())
+                .bind(1, resultExample1.getCorrectAnswers())
+                .execute();
+        handle.createStatement("INSERT INTO results VALUES (?, ?)")
+                .bind(0, resultExample2.getId())
+                .bind(1, resultExample2.getCorrectAnswers())
+                .execute();
+        handle.createCall("DROP TABLE flashcards IF EXISTS").invoke();
+        handle.createCall(
+                "CREATE TABLE flashcards (id uuid primary key, question varchar(50) not null, answer varchar(50) not null, deckID uuid)")
+                .invoke();
+        handle.createStatement("INSERT INTO flashcards VALUES (?, ?, ?, ?)")
+                .bind(0, flashcardExample1.getId())
+                .bind(1, flashcardExample1.getQuestion())
+                .bind(2, flashcardExample1.getAnswer())
+                .bind(3, flashcardExample1.getDeckID())
+                .execute();
+        handle.createStatement("INSERT INTO flashcards VALUES (?, ?, ?, ?)")
+                .bind(0, flashcardExample2.getId())
+                .bind(1, flashcardExample2.getQuestion())
+                .bind(2, flashcardExample2.getAnswer())
+                .bind(3, flashcardExample1.getDeckID())
+                .execute();
+    }
+
+    @Test
+    public void getAllResults() {
+        final List<Result> results = dao.getAllResults(deckID);
+        assertThat(results).containsSequence(resultExample1, resultExample2);
+    }
+
+    @Test
+    public void getResultById() {
+        final Result result = dao.getResult(resultExample1.getId());
+        assertThat(result).isEqualTo(resultExample1);
+    }
+
+    @Test
+    public void createResult() {
+        final Result result = new Result(UUID.randomUUID(), new Random().nextInt());
+        dao.createResult(result);
+        assertThat(dao.getResult(result.getId())).isEqualTo(result);
+    }
+
+    @Test
+    public void deleteResult() {
+        dao.deleteResult(resultExample2.getId());
+        assertThat(dao.getAllResults(deckID)).doesNotContain(resultExample2);
+    }
+
+    @Test
+    public void updateResult() {
+        final Result result = new Result(resultExample1.getId(), new Random().nextInt());
+        dao.updateResult(result);
+        assertThat(dao.getResult(resultExample1.getId())).isEqualTo(result);
+    }
+}


### PR DESCRIPTION
Here's the tested implementation of STUDYBOX-106, allowing us to store the results for flashcards.

- [x] I included separated changeset in migrations - Result entity doesn't contain any separated id for itself - it's primary key is the flashcard UUID of which it contain results. 
- [x] Request, in boolean, is parsed weather or not to increment a correctAnswers field, which holds the overall statistics for a Flashcard. 
- [x] When results are posted for the first time, resource creates a new instance of them, if not, it operates on the values from database
