### PR TITLE
Adding access change endpoint to Apiary

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -373,10 +373,10 @@ By default API return response with HTTP code **4xx** family.
 
 ### DeckWithoutId (object)
 + name: `Sample name` (string, required) - name attribute for Deck
++ isPublic: `true` (boolean, required) - status of Deck access rights
 
 ### Deck (DeckWithoutId)
 + id: `12345678-9012-3456-7890-123456789012` (string, required) - Deck UUID, 36 chars, 8-4-4-4-12 chars
-+ public: `true` (boolean, required) - status of Deck access rights
 
 ### FlashcardWithoutId (object)
 + question: `Sample question` (string, required) - question attribute for Flashcard

--- a/apiary.apib
+++ b/apiary.apib
@@ -114,6 +114,14 @@ By default API return response with HTTP code **4xx** family.
 
 + Response 204
 
+### Change access to Deck [POST /decks/{deckId}/public/{isPublic}]
+
++ Parameters
+    + deckId: `1212-1212-1212-121212121212` (string, required) - deck UUID to update
+    + isPublic: false (boolean, required) - value to be set in isPublic field
+
++ Response 204
+
 # Group Flashcard
 
 ## Flashcards [/decks/{deckId}/flashcards]


### PR DESCRIPTION
Updated Apiary, as STUDYBOX-227 specifies. 
I used path /decks/{deckId}/public/{isPublic}, because, in my opinion, it's clear and easy to understand