### PR TITLE
Adding anonymous/default user

### DIFF
--- a/backend/app/src/main/java/com/bls/patronage/StudyBox.java
+++ b/backend/app/src/main/java/com/bls/patronage/StudyBox.java
@@ -1,6 +1,7 @@
 package com.bls.patronage;
 
 import com.bls.patronage.auth.BasicAuthenticator;
+import com.bls.patronage.auth.PreAuthenticationFilter;
 import com.bls.patronage.db.dao.DeckDAO;
 import com.bls.patronage.db.dao.FlashcardDAO;
 import com.bls.patronage.db.dao.TipDAO;
@@ -85,5 +86,7 @@ public class StudyBox extends Application<StudyBoxConfiguration> {
 
             environment.jersey().register(new AuthValueFactoryProvider.Binder<>(User.class));
         }
+
+        environment.jersey().register(PreAuthenticationFilter.class);
     }
 }

--- a/backend/app/src/main/java/com/bls/patronage/StudyBox.java
+++ b/backend/app/src/main/java/com/bls/patronage/StudyBox.java
@@ -7,14 +7,14 @@ import com.bls.patronage.db.dao.TipDAO;
 import com.bls.patronage.db.dao.UserDAO;
 import com.bls.patronage.db.exception.DataAccessExceptionMapper;
 import com.bls.patronage.db.model.User;
-import com.bls.patronage.resources.FlashcardResource;
-import com.bls.patronage.resources.FlashcardsResource;
-import com.bls.patronage.resources.UserResource;
-import com.bls.patronage.resources.UsersResource;
-import com.bls.patronage.resources.TipResource;
-import com.bls.patronage.resources.TipsResource;
 import com.bls.patronage.resources.DeckResource;
 import com.bls.patronage.resources.DecksResource;
+import com.bls.patronage.resources.FlashcardResource;
+import com.bls.patronage.resources.FlashcardsResource;
+import com.bls.patronage.resources.TipResource;
+import com.bls.patronage.resources.TipsResource;
+import com.bls.patronage.resources.UserResource;
+import com.bls.patronage.resources.UsersResource;
 import io.dropwizard.Application;
 import io.dropwizard.auth.AuthDynamicFeature;
 import io.dropwizard.auth.AuthValueFactoryProvider;
@@ -28,8 +28,6 @@ import io.dropwizard.migrations.MigrationsBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import org.skife.jdbi.v2.DBI;
-
-import static com.bls.patronage.StudyBoxConfiguration.isAuthenticationEnabled;
 
 public class StudyBox extends Application<StudyBoxConfiguration> {
 
@@ -79,7 +77,7 @@ public class StudyBox extends Application<StudyBoxConfiguration> {
         final BasicAuthenticator basicAuthenticator = new BasicAuthenticator(jdbi.onDemand(UserDAO.class));
         final CachingAuthenticator cachingAuthenticator = new CachingAuthenticator(environment.metrics(), basicAuthenticator,
                 configuration.getAuthCacheBuilder());
-        if(isAuthenticationEnabled) {
+        if (configuration.getIsAuthenticationEnabled()) {
             environment.jersey().register(new AuthDynamicFeature(
                     new BasicCredentialAuthFilter.Builder<User>()
                             .setAuthenticator(cachingAuthenticator)

--- a/backend/app/src/main/java/com/bls/patronage/StudyBoxConfiguration.java
+++ b/backend/app/src/main/java/com/bls/patronage/StudyBoxConfiguration.java
@@ -1,5 +1,6 @@
 package com.bls.patronage;
 
+import com.bls.patronage.db.model.User;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.cache.CacheBuilder;
 import io.dropwizard.Configuration;
@@ -10,13 +11,15 @@ import javax.validation.constraints.NotNull;
 
 public class StudyBoxConfiguration extends Configuration {
     @NotNull
-    public static Boolean isAuthenticationEnabled;
     public static final int PW_HASH_SECURITY_LEVEL = 12;
     private static final String DEFAULT_AUTH_CACHE_SPEC = "maximumSize=1000,expireAfterAccess=1h";
-
+    public Boolean isAuthenticationEnabled;
     @Valid
     @NotNull
     private DataSourceFactory database = new DataSourceFactory();
+    @Valid
+    @NotNull
+    private User defaultUser;
 
     public DataSourceFactory getDatabase() {
         return database;
@@ -34,5 +37,15 @@ public class StudyBoxConfiguration extends Configuration {
 
     public CacheBuilder<Object, Object> getAuthCacheBuilder() {
         return CacheBuilder.from(DEFAULT_AUTH_CACHE_SPEC);
+    }
+
+    @JsonProperty
+    public User getDefaultUser() {
+        return this.defaultUser;
+    }
+
+    @JsonProperty
+    public void setDefaultUser(User defaultUser) {
+        this.defaultUser = defaultUser;
     }
 }

--- a/backend/app/src/main/java/com/bls/patronage/StudyBoxConfiguration.java
+++ b/backend/app/src/main/java/com/bls/patronage/StudyBoxConfiguration.java
@@ -1,6 +1,5 @@
 package com.bls.patronage;
 
-import com.bls.patronage.db.model.User;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.cache.CacheBuilder;
 import io.dropwizard.Configuration;
@@ -17,9 +16,6 @@ public class StudyBoxConfiguration extends Configuration {
     @Valid
     @NotNull
     private DataSourceFactory database = new DataSourceFactory();
-    @Valid
-    @NotNull
-    private User defaultUser;
 
     public DataSourceFactory getDatabase() {
         return database;
@@ -39,13 +35,4 @@ public class StudyBoxConfiguration extends Configuration {
         return CacheBuilder.from(DEFAULT_AUTH_CACHE_SPEC);
     }
 
-    @JsonProperty
-    public User getDefaultUser() {
-        return this.defaultUser;
-    }
-
-    @JsonProperty
-    public void setDefaultUser(User defaultUser) {
-        this.defaultUser = defaultUser;
-    }
 }

--- a/backend/app/src/main/java/com/bls/patronage/api/UserRepresentation.java
+++ b/backend/app/src/main/java/com/bls/patronage/api/UserRepresentation.java
@@ -9,7 +9,6 @@ public class UserRepresentation {
     @Email
     @NotEmpty
     private final String email;
-    @NotEmpty
     private final String name;
     @NotEmpty
     @Length(min = 8)

--- a/backend/app/src/main/java/com/bls/patronage/auth/BasicAuthenticator.java
+++ b/backend/app/src/main/java/com/bls/patronage/auth/BasicAuthenticator.java
@@ -6,7 +6,10 @@ import com.google.common.base.Optional;
 import io.dropwizard.auth.AuthenticationException;
 import io.dropwizard.auth.Authenticator;
 import io.dropwizard.auth.basic.BasicCredentials;
+import org.glassfish.jersey.internal.util.Base64;
 import org.mindrot.jbcrypt.BCrypt;
+
+import java.util.UUID;
 
 import static com.bls.patronage.StudyBoxConfiguration.PW_HASH_SECURITY_LEVEL;
 import static com.google.common.base.Preconditions.checkState;
@@ -32,6 +35,9 @@ public class BasicAuthenticator implements Authenticator<BasicCredentials, User>
 
         String email = basicCredentials.getUsername();
         String plaintextPassword = basicCredentials.getPassword();
+
+        if (email.equals(PreAuthenticationFilter.defultUserEmail))
+            return Optional.of(new User(UUID.randomUUID(), email, "", Base64.encodeAsString(plaintextPassword)));
 
         final Optional<User> user = Optional.fromNullable(userDao.getUserByEmail(email));
         if (user.isPresent()) {

--- a/backend/app/src/main/java/com/bls/patronage/auth/BasicAuthenticator.java
+++ b/backend/app/src/main/java/com/bls/patronage/auth/BasicAuthenticator.java
@@ -39,7 +39,7 @@ public class BasicAuthenticator implements Authenticator<BasicCredentials, User>
         if (email.equals(PreAuthenticationFilter.defultUserEmail))
             return Optional.of(new User(UUID.randomUUID(), email, "", Base64.encodeAsString(plaintextPassword)));
 
-        final Optional<User> user = Optional.fromNullable(userDao.getUserByEmail(email));
+        final Optional<User> user = Optional.of(userDao.getUserByEmail(email));
         if (user.isPresent()) {
             final User existingUser = user.get();
             checkState(existingUser.getPassword() != null, "Cannot authenticate: user with id: %s (email: %s) without password",

--- a/backend/app/src/main/java/com/bls/patronage/auth/BasicAuthenticator.java
+++ b/backend/app/src/main/java/com/bls/patronage/auth/BasicAuthenticator.java
@@ -33,7 +33,7 @@ public class BasicAuthenticator implements Authenticator<BasicCredentials, User>
         String email = basicCredentials.getUsername();
         String plaintextPassword = basicCredentials.getPassword();
 
-        final Optional<User> user = Optional.of(userDao.getUserByEmail(email));
+        final Optional<User> user = Optional.fromNullable(userDao.getUserByEmail(email));
         if (user.isPresent()) {
             final User existingUser = user.get();
             checkState(existingUser.getPassword() != null, "Cannot authenticate: user with id: %s (email: %s) without password",

--- a/backend/app/src/main/java/com/bls/patronage/auth/PreAuthenticationFilter.java
+++ b/backend/app/src/main/java/com/bls/patronage/auth/PreAuthenticationFilter.java
@@ -1,0 +1,31 @@
+package com.bls.patronage.auth;
+
+import org.glassfish.jersey.internal.util.Base64;
+
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.HttpHeaders;
+import java.io.IOException;
+
+@Priority(Priorities.AUTHENTICATION - 100)
+public class PreAuthenticationFilter implements ContainerRequestFilter {
+
+    @Override
+    public void filter(ContainerRequestContext request) throws IOException {
+        boolean hasValidHeader = false;
+        if (request.getHeaders().containsKey(HttpHeaders.AUTHORIZATION)) {
+            final String header = request.getHeaderString(HttpHeaders.AUTHORIZATION);
+            if (header.toLowerCase().startsWith("basic")) {
+                hasValidHeader = true;
+            }
+        }
+        if (!hasValidHeader) {
+            final String defaultUser = "anon2";
+            final String defaultPassword = "password";
+            final String base64 = Base64.encodeAsString(defaultUser + ":" + defaultPassword);
+            request.getHeaders().putSingle(HttpHeaders.AUTHORIZATION, "Basic " + base64);
+        }
+    }
+}

--- a/backend/app/src/main/java/com/bls/patronage/auth/PreAuthenticationFilter.java
+++ b/backend/app/src/main/java/com/bls/patronage/auth/PreAuthenticationFilter.java
@@ -11,7 +11,8 @@ import java.io.IOException;
 
 @Priority(Priorities.AUTHENTICATION - 100)
 public class PreAuthenticationFilter implements ContainerRequestFilter {
-
+    public static String defultUserEmail = "anon";
+    public static String defultUserPassword = "password";
     @Override
     public void filter(ContainerRequestContext request) throws IOException {
         boolean hasValidHeader = false;
@@ -22,9 +23,7 @@ public class PreAuthenticationFilter implements ContainerRequestFilter {
             }
         }
         if (!hasValidHeader) {
-            final String defaultUser = "anon2";
-            final String defaultPassword = "password";
-            final String base64 = Base64.encodeAsString(defaultUser + ":" + defaultPassword);
+            final String base64 = Base64.encodeAsString(defultUserEmail + ":" + defultUserPassword);
             request.getHeaders().putSingle(HttpHeaders.AUTHORIZATION, "Basic " + base64);
         }
     }

--- a/backend/app/src/main/java/com/bls/patronage/resources/UserResource.java
+++ b/backend/app/src/main/java/com/bls/patronage/resources/UserResource.java
@@ -32,8 +32,10 @@ public class UserResource {
 
     @Path("/me")
     @GET
-    public UserWithoutPassword logInUser(@Auth User userCredentials) {
-        final User user = userDAO.getUserByEmail(userCredentials.getEmail());
-        return new UserWithoutPassword(user.getId(), user.getEmail(), user.getName());
+    public UserWithoutPassword logInUser(@Auth User user) {
+        return new UserWithoutPassword(
+                user.getId(),
+                user.getEmail(),
+                user.getName());
     }
 }

--- a/backend/app/src/main/java/com/bls/patronage/resources/UserResource.java
+++ b/backend/app/src/main/java/com/bls/patronage/resources/UserResource.java
@@ -6,7 +6,6 @@ import com.bls.patronage.db.model.UserWithoutPassword;
 import io.dropwizard.auth.Auth;
 import io.dropwizard.jersey.params.UUIDParam;
 
-import javax.annotation.security.PermitAll;
 import javax.validation.Valid;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -23,7 +22,7 @@ public class UserResource {
         this.userDAO = userDAO;
     }
 
-    @Path("/{userId}")
+    @Path("/{userId: [0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}}")
     @GET
     public UserWithoutPassword getUser(
             @Valid @PathParam("userId") UUIDParam userId) {

--- a/backend/app/src/test/java/com/bls/patronage/appTests.xml
+++ b/backend/app/src/test/java/com/bls/patronage/appTests.xml
@@ -4,6 +4,7 @@
 <suite name="Application Tests">
     <test name="Resource Tests" junit="true">
         <classes>
+            <class name="com.bls.patronage.resources.BasicAuthenticationTest"/>
             <class name="com.bls.patronage.resources.DeckResourceTest"/>
             <class name="com.bls.patronage.resources.DecksResourceTest"/>
             <class name="com.bls.patronage.resources.FlashcardResourceTest"/>

--- a/backend/app/src/test/java/com/bls/patronage/resources/BasicAuthenticationTest.java
+++ b/backend/app/src/test/java/com/bls/patronage/resources/BasicAuthenticationTest.java
@@ -1,7 +1,9 @@
 package com.bls.patronage.resources;
 
 
+import com.bls.patronage.StudyBoxConfiguration;
 import com.bls.patronage.auth.BasicAuthenticator;
+import com.bls.patronage.auth.PreAuthenticationFilter;
 import com.bls.patronage.db.dao.DeckDAO;
 import com.bls.patronage.db.dao.UserDAO;
 import com.bls.patronage.db.exception.DataAccessExceptionMapper;
@@ -15,6 +17,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.mindrot.jbcrypt.BCrypt;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -23,8 +26,10 @@ import java.util.Base64;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
 
 public class BasicAuthenticationTest {
     protected static final UserDAO userDAO = mock(UserDAO.class);
@@ -39,6 +44,7 @@ public class BasicAuthenticationTest {
                     .buildAuthFilter()))
             .addProvider(RolesAllowedDynamicFeature.class)
             .addProvider(new AuthValueFactoryProvider.Binder<>(User.class))
+            .addProvider(PreAuthenticationFilter.class)
             .addResource(new UserResource(userDAO))
             .addResource(new DecksResource(deckDao))
             .addResource(new DeckResource(deckDao))
@@ -75,6 +81,9 @@ public class BasicAuthenticationTest {
 
     @Test
     public void logInAsAnonymousUser() {
+        User defaultUser = new User(UUID.randomUUID(), "anon", "", BCrypt.hashpw("password", BCrypt.gensalt(StudyBoxConfiguration.PW_HASH_SECURITY_LEVEL)));
+        when(userDAO.getUserByEmail(any(String.class))).thenReturn(defaultUser);
+
         String testURI = UriBuilder
                 .fromResource(UserResource.class)
                 .build().toString() + UriBuilder.fromMethod(UserResource.class, "logInUser").build().toString();
@@ -82,6 +91,6 @@ public class BasicAuthenticationTest {
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .get();
 
-        assertThat(response.getStatus()).isEqualTo(Response.Status.OK);
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
     }
 }

--- a/backend/app/src/test/java/com/bls/patronage/resources/BasicAuthenticationTest.java
+++ b/backend/app/src/test/java/com/bls/patronage/resources/BasicAuthenticationTest.java
@@ -14,12 +14,15 @@ import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Test;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
 import java.util.Base64;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 
@@ -47,6 +50,13 @@ public class BasicAuthenticationTest {
     protected String badEmailCredentials;
     protected String fakeEmail;
 
+    static protected Response getResponseWithCredentials(String uri, String encodedUserInfo) {
+        return authResources.client().target(uri)
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .header("Authorization", "Basic " + encodedUserInfo)
+                .get();
+    }
+
     @Before
     public void setUp() {
         user = new User(UUID.randomUUID(), "foo@mail.com", "bar",
@@ -63,10 +73,15 @@ public class BasicAuthenticationTest {
         reset(deckDao);
     }
 
-    static protected Response getResponseWithCredentials(String uri, String encodedUserInfo) {
-        return authResources.client().target(uri)
+    @Test
+    public void logInAsAnonymousUser() {
+        String testURI = UriBuilder
+                .fromResource(UserResource.class)
+                .build().toString() + UriBuilder.fromMethod(UserResource.class, "logInUser").build().toString();
+        Response response = authResources.client().target(testURI)
                 .request(MediaType.APPLICATION_JSON_TYPE)
-                .header("Authorization", "Basic " + encodedUserInfo)
                 .get();
+
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK);
     }
 }

--- a/backend/app/src/test/java/com/bls/patronage/resources/BasicAuthenticationTest.java
+++ b/backend/app/src/test/java/com/bls/patronage/resources/BasicAuthenticationTest.java
@@ -1,7 +1,6 @@
 package com.bls.patronage.resources;
 
 
-import com.bls.patronage.StudyBoxConfiguration;
 import com.bls.patronage.auth.BasicAuthenticator;
 import com.bls.patronage.auth.PreAuthenticationFilter;
 import com.bls.patronage.db.dao.DeckDAO;
@@ -17,7 +16,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.mindrot.jbcrypt.BCrypt;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -26,10 +24,8 @@ import java.util.Base64;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.when;
 
 public class BasicAuthenticationTest {
     protected static final UserDAO userDAO = mock(UserDAO.class);
@@ -81,9 +77,6 @@ public class BasicAuthenticationTest {
 
     @Test
     public void logInAsAnonymousUser() {
-        User defaultUser = new User(UUID.randomUUID(), "anon", "", BCrypt.hashpw("password", BCrypt.gensalt(StudyBoxConfiguration.PW_HASH_SECURITY_LEVEL)));
-        when(userDAO.getUserByEmail(any(String.class))).thenReturn(defaultUser);
-
         String testURI = UriBuilder
                 .fromResource(UserResource.class)
                 .build().toString() + UriBuilder.fromMethod(UserResource.class, "logInUser").build().toString();

--- a/backend/app/src/test/java/com/bls/patronage/resources/UserResourceTest.java
+++ b/backend/app/src/test/java/com/bls/patronage/resources/UserResourceTest.java
@@ -14,7 +14,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -58,7 +57,7 @@ public class UserResourceTest extends BasicAuthenticationTest {
         final Response response = getResponseWithCredentials(loggingURI, encodedCredentials);
         final UserWithoutPassword receivedUser = response.readEntity(UserWithoutPassword.class);
 
-        verify(userDAO, times(2)).getUserByEmail(user.getEmail());
+        verify(userDAO).getUserByEmail(user.getEmail());
         assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
         assertThat(receivedUser.getId()).isEqualTo(user.getId());
         assertThat(receivedUser.getName()).isEqualTo(user.getName());

--- a/backend/app/src/test/java/com/bls/patronage/resources/UsersResourceTest.java
+++ b/backend/app/src/test/java/com/bls/patronage/resources/UsersResourceTest.java
@@ -35,6 +35,12 @@ public class UsersResourceTest {
     private String usersURI;
     private User user;
 
+    static private Response postUser(String uri, String email, String name, String password) {
+        return resources.client().target(uri)
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .post(Entity.entity(new UserRepresentation(email, name, password), MediaType.APPLICATION_JSON_TYPE));
+    }
+
     @Before
     public void setUp() {
         usersURI = UriBuilder.fromResource(UsersResource.class).build().toString();
@@ -63,9 +69,9 @@ public class UsersResourceTest {
         assertThat(response.getStatusInfo().getStatusCode()).isEqualTo(422);
     }
 
-    static private Response postUser(String uri, String email, String name, String password) {
-        return resources.client().target(uri)
-                .request(MediaType.APPLICATION_JSON_TYPE)
-                .post(Entity.entity(new UserRepresentation(email, name, password), MediaType.APPLICATION_JSON_TYPE));
+    @Test
+    public void createUserWithNoName() {
+        Response response = postUser(usersURI, "zxc", "", user.getPassword());
+        assertThat(response.getStatusInfo().getStatusCode()).isEqualTo(422);
     }
 }

--- a/backend/app/studybox-h2.yml
+++ b/backend/app/studybox-h2.yml
@@ -5,9 +5,3 @@ database:
   url: jdbc:h2:./target/studybox.db
 
 isAuthenticationEnabled: true
-
-defaultUser:
-  id: 11111111-0000-1111-0000-111111111111
-  email: anon@backend.com
-  name: anon
-  password: secret

--- a/backend/app/studybox-h2.yml
+++ b/backend/app/studybox-h2.yml
@@ -5,3 +5,9 @@ database:
   url: jdbc:h2:./target/studybox.db
 
 isAuthenticationEnabled: true
+
+defaultUser:
+  id: 11111111-0000-1111-0000-111111111111
+  email: anon@backend.com
+  name: anon
+  password: secret


### PR DESCRIPTION
I handled this issue this way - added PreAuthFilter, which searches for the header, an if there isn't any, it gives anon user header. 

Thanks to this solution, we have perfectly hermetic mechanism, which we can very easily turn off.  
However, we need to have anon user in our database, because Authenticator still needs to compare credentials to existing user
